### PR TITLE
Add support for nested classes

### DIFF
--- a/ICG/icg_main.hpp
+++ b/ICG/icg_main.hpp
@@ -20,12 +20,6 @@ class FieldInfo final : public recursable {
     FieldInfo (std::string n, std::string t, AccessLevel a);
 
     // Rule of 5 is default
-    FieldInfo (const FieldInfo& other) = default;
-    ~FieldInfo () = default;
-    FieldInfo& operator= (FieldInfo& other) = default;
-    FieldInfo(FieldInfo&& other) = default;
-    FieldInfo& operator=(FieldInfo&& other) = default;
-
 
     std::string type;
     std::string name;
@@ -48,11 +42,6 @@ public:
     ClassInfo(std::string n);
 
     // Rule of 5 is default
-    ClassInfo (const ClassInfo& other) = default;
-    ~ClassInfo () = default;
-    ClassInfo& operator= (ClassInfo& other) = default;
-    ClassInfo(ClassInfo&& other) = default;
-    ClassInfo& operator=(ClassInfo&& other) = default;
 
     std::string name;
     std::vector<FieldInfo> fields;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,4 +36,5 @@ endmacro()
 
 add_icg_integration_test(basic_checkpoint_restore header.hpp)
 add_icg_integration_test(namespaces bar.hpp)
+add_icg_integration_test(nested_classes bar.hpp)
 

--- a/test/basic_checkpoint_restore/test_main.cpp
+++ b/test/basic_checkpoint_restore/test_main.cpp
@@ -11,10 +11,9 @@ TEST_F(ICGTest, CheckpointRestore) {
     memoryManager.declare_var("MyClass * ptr", &my_class_instance);
     
     // ACT
-    bool success = memoryManager.restore_checkpoint("checkpoint.txt");
+    memoryManager.restore_checkpoint("checkpoint.txt");
 
     // ASSERT
-    ASSERT_TRUE(success) << "Run this test from 'make check'/'make test'/'ctest' OR from the test/basic_checkpoint_restore directory";
     for (int i = 0; i < 5; i++) {
         ASSERT_EQ(my_class_instance->my_nested_class.my_arr[i], i+5);
     }

--- a/test/basic_checkpoint_restore/test_main.cpp
+++ b/test/basic_checkpoint_restore/test_main.cpp
@@ -11,9 +11,10 @@ TEST_F(ICGTest, CheckpointRestore) {
     memoryManager.declare_var("MyClass * ptr", &my_class_instance);
     
     // ACT
-    memoryManager.restore_checkpoint("checkpoint.txt");
+    bool success = memoryManager.restore_checkpoint("checkpoint.txt");
 
     // ASSERT
+    ASSERT_TRUE(success) << "Run this test from 'make check'/'make test'/'ctest' OR from the test/basic_checkpoint_restore directory";
     for (int i = 0; i < 5; i++) {
         ASSERT_EQ(my_class_instance->my_nested_class.my_arr[i], i+5);
     }

--- a/test/nested_classes/bar.hpp
+++ b/test/nested_classes/bar.hpp
@@ -1,0 +1,13 @@
+/*
+PURPOSE:
+    ( Work with namespaces )
+PROGRAMMERS:
+    ()
+*/
+#include "foo.hpp"
+
+class Bar {
+public:
+    Foo foo;
+    Foo::Bar foobar;
+};

--- a/test/nested_classes/foo.hpp
+++ b/test/nested_classes/foo.hpp
@@ -1,0 +1,14 @@
+
+#include <string>
+
+using std::string;
+
+class Foo {
+    public:
+    int x;
+
+    class Bar {
+        public:
+        int y;
+    };
+};

--- a/test/nested_classes/test_main.cpp
+++ b/test/nested_classes/test_main.cpp
@@ -1,0 +1,50 @@
+#include "io_bar.hpp"
+#include "MemoryManagement/AllocInfo.hpp"
+
+#include "ICGTestFixture.hpp"
+
+
+TEST_F(ICGTest, nested_classes_checkpoint_restore) {
+    // ARRANGE
+    std::string checkpoint_str = "Bar b ;\nb.foo.x = 4 ;\nb.foobar.y = 2 ;\nb_ptr = &b ;\n";
+    Bar * b_ptr = (Bar *) memoryManager.declare_var("Bar b");
+    memoryManager.declare_var("Bar * b_ptr", &b_ptr);
+
+    std::stringstream ss(checkpoint_str);
+
+    // ACT
+    memoryManager.restore_checkpoint(ss);
+
+    // ASSERT
+    ASSERT_TRUE(b_ptr != NULL);
+    ASSERT_EQ(4, b_ptr->foo.x);
+    ASSERT_EQ(2, b_ptr->foobar.y);
+}
+
+TEST_F(ICGTest, nested_classes_dump_and_restore) {
+    // ARRANGE
+    Bar * b_ptr = (Bar *) memoryManager.declare_var("Bar b");
+    memoryManager.declare_var("Bar * b_ptr", &b_ptr);
+
+    b_ptr->foo.x = 4;
+    b_ptr->foobar.y = 2;
+
+    // dump a checkpoint
+    std::stringstream ss;
+    memoryManager.write_checkpoint(ss);
+
+    // Change it to something else
+    b_ptr->foo.x = 400;
+    b_ptr->foobar.y = 200;
+
+    // Restore the first checkpoint
+    memoryManager.restore_checkpoint(ss);
+
+    // ASSERT
+    ASSERT_TRUE(b_ptr != NULL);
+    ASSERT_EQ(4, b_ptr->foo.x);
+    ASSERT_EQ(2, b_ptr->foobar.y);
+}
+
+
+


### PR DESCRIPTION
Add support and test for nested classes.

This was an easy change once the namespace support was added. Just required adding a ClassDecl case inside the ClassVisitor in ICG. No Datatypes changes were necessary.