### PR TITLE
Refactor validate

### DIFF
--- a/DataTypes/include/DataTypeInator.hpp
+++ b/DataTypes/include/DataTypeInator.hpp
@@ -57,9 +57,8 @@
 #include "Type/DataType.hpp"
 #include "Type/BaseType.hpp"
 
-#include "TypeDictionary.hpp"
-#include <map>
 
+class TypeDictionary;
 
 class DataTypeInator {
     public:

--- a/DataTypes/include/Type/ArrayDataType.hpp
+++ b/DataTypes/include/Type/ArrayDataType.hpp
@@ -13,13 +13,14 @@
 class ArrayDataType : public ModifierType {
 
     public:
+
     /**
-     Constructor for ArrayDataType.
-     @param typeSpecifierName Name of the type on with this type is based.
-     @param n_elems Number of elements.
+     * @brief Construct an ArrayDataType
+     * 
+     * @param typeSpecifierName string representation of fully qualified type
+     * @param n_elems Number of 
      */
-    ArrayDataType( const DataTypeInator* inator,
-                   std::string typeSpecifierName,
+    ArrayDataType( std::string typeSpecifierName,
                    unsigned int n_elems )  ;
 
     /**
@@ -60,7 +61,7 @@ class ArrayDataType : public ModifierType {
 
     /**
      */
-     bool validate() override;
+     bool validate(const DataTypeInator* dataTypeInator) override;
 
      bool isValid() const override;
 
@@ -122,8 +123,5 @@ class ArrayDataType : public ModifierType {
     unsigned int elementCount;
     bool is_valid;
     std::string typeSpecName;
-
-    const DataTypeInator* dataTypeInator;
-
 };
 

--- a/DataTypes/include/Type/BaseType.hpp
+++ b/DataTypes/include/Type/BaseType.hpp
@@ -2,6 +2,8 @@
 
 #include "Type/DataType.hpp"
 
-class BaseType : public DataType {
-
-};
+/**
+ * @brief Abstract class to represent a class that can go in the TypeDictionary (aka not an array or pointer)
+ * 
+ */
+class BaseType : public DataType {};

--- a/DataTypes/include/Type/CompositeDataType.hpp
+++ b/DataTypes/include/Type/CompositeDataType.hpp
@@ -26,8 +26,7 @@ public:
      Constructor for CompositeDataType.
      @param sizeof_struct Size, in bytes, of the struct, class or union that this class represents.
      */
-    CompositeDataType( DataTypeInator* dataTypeInator,
-                       std::string name,
+    CompositeDataType( std::string name,
                        size_t sizeof_struct,
                        void *(*allocator)(int),
                        void (*deAllocator)(void*) );
@@ -52,7 +51,7 @@ public:
 
     /**
      */
-    bool validate() override;
+    bool validate(const DataTypeInator* dataTypeInator) override;
 
     bool isValid() const override;
 
@@ -84,36 +83,35 @@ public:
     /* ==================================================================== */
 
     /**
-     Add a regular, non-bitfield, non-static data member to the CompositeDataType.
-     @param memberName Name of the data member.
-     @param offset The offset (in bytes) of the data-member from the beginning of
-     the struct, union or class.
-     @param typeName
-     @param n_dims
-     @param dims
+     * @brief Add a nonstatic member variable to this type
+     * 
+     * @param memberName name of member
+     * @param offset offset within containing type
+     * @param typeName string representation of the fully qualified type of the member
      */
     void addRegularMember( std::string memberName,
                            int offset,
                            std::string typeName) ;
 
     /**
-     Add a static data member to the CompositeDataType.
-     @param memberName Name of the data member.
-     @param memberAddress The offset (in bytes) of the data-member from the beginning of
-     the struct, union or class.
-     @param typeName
-     @param n_dims
-     @param dims
+     * @brief Add a static member variable to this type
+     * 
+     * @param memberName name of member
+     * @param memberAddress address of member
+     * @param typeSpecName string representation of fully qualified type
      */
     void addStaticMember(std::string memberName,
                          void * memberAddress,
                          std::string typeSpecName ) ;
 
     /**
-     Add a bitfield data member to the CompositeDataType.
+     @brief Add a bitfield data member to the CompositeDataType.
+
+     @todo this doesn't actually work.
+
      @param member_name Name of the data member.
      @param getter Pointer to a function that returns the value of a bitfield in the addressed class/struct.
-     @param getter Pointer to a function that sets the value of a bitfield in the addressed class/struct.
+     @param setter Pointer to a function that sets the value of a bitfield in the addressed class/struct.
      */
     template <class T> void addBitFieldMember( std::string member_name,
                                                T(*getter)(void* address),
@@ -168,6 +166,4 @@ private:
 
     void* (*allocator)(int);
     void (*deAllocator)(void*);
-
-    DataTypeInator* dataTypeInator;
 };

--- a/DataTypes/include/Type/DataType.hpp
+++ b/DataTypes/include/Type/DataType.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
-#include "Value/Value.hpp"
 #include "Algorithm/DataTypeVisitor.hpp"
-#include "Utils/MutableVariableName.hpp"
+
+class DataTypeInator;
 
 /** @brief Abstract base class for DataTypes. */
 class DataType {
@@ -19,9 +18,10 @@ class DataType {
     * subordinate DataTypes are resolvable to actual DataTypes in
     * the TypeDictionary.
     * 
-    * @return true if validation is successful, false otherwise 
+    * @param dataTypeInator - type resolver machine
+    * @return true if successful, false otherwise
     */
-    virtual bool validate() = 0;
+    virtual bool validate(const DataTypeInator* dataTypeInator) = 0;
 
     /**
      * @brief Determine whether this type has already been successfully validated.

--- a/DataTypes/include/Type/EnumDataType.hpp
+++ b/DataTypes/include/Type/EnumDataType.hpp
@@ -20,8 +20,11 @@ class EnumDataType : public BaseType {
 public:
 
     /**
-     Constructor for EnumDataType.
-     @param sizeof_element Size, in bytes, of one eneumeration element.
+     * @brief Constructor for an Enumerated type object
+     * 
+     * @param enumDictionary global enum value dictionary
+     * @param name name of type
+     * @param sizeof_element size, in bytes, of this type
      */
     EnumDataType( EnumDictionary* enumDictionary,
                   std::string name,
@@ -47,7 +50,7 @@ public:
 
     /**
      */
-    bool validate() override;
+    bool validate(const DataTypeInator* dataTypeInator = NULL) override;
 
     bool isValid() const override;
 

--- a/DataTypes/include/Type/ModifierType.hpp
+++ b/DataTypes/include/Type/ModifierType.hpp
@@ -2,9 +2,15 @@
 
 #include "Type/DataType.hpp"
 
+/**
+ * @brief A type that only exists to provide a modifier to a subtype. Pointer and array
+ * 
+ */
 class ModifierType : public DataType {
 
     public: 
+        ModifierType() : subType(NULL) {}
+
         const DataType * getSubType() const {
             return subType;
         }

--- a/DataTypes/include/Type/PointerDataType.hpp
+++ b/DataTypes/include/Type/PointerDataType.hpp
@@ -16,11 +16,10 @@ class PointerDataType : public ModifierType {
 
     /**
      Constructor for ArrayDataType.
-     @param DataTypeInator The Type resolver machine
+     @param dataTypeInator The Type resolver machine
      @param typeSpecifierName Name of the type on with this type is based.
      */
-    PointerDataType( const DataTypeInator * dataTypeInator,
-                     std::string typeSpecifierName ) ;
+    PointerDataType( std::string typeSpecifierName ) ;
 
     /* ================================================================================= */
     /*                         RULE OF THREE (and a half) INTERFACE                      */
@@ -38,7 +37,7 @@ class PointerDataType : public ModifierType {
 
     /**
      */
-     bool validate() override;
+    bool validate(const DataTypeInator * dataTypeInator) override;
 
     bool isValid() const override;
 

--- a/DataTypes/include/Type/SpecifiedPrimitiveDataType.hpp
+++ b/DataTypes/include/Type/SpecifiedPrimitiveDataType.hpp
@@ -28,37 +28,35 @@ public:
     /*                          VIRTUAL INTERFACE                           */
     /* ==================================================================== */
 
-    /**
-     */
-    bool validate() { return true; }
+    bool validate(const DataTypeInator * dataTypeInator = NULL) override { return true; }
 
-    bool isValid() const { return true; }
+    bool isValid() const override { return true; }
     
     /**
      @return The size (in bytes) of an instance of the DataType
      */
-    size_t getSize() const {
+    size_t getSize() const override {
         return sizeof(T);
     }
 
 
     /**
      */
-    SpecifiedPrimitiveDataType<T> * clone () const {
+    DataType * clone () const override {
         return new SpecifiedPrimitiveDataType<T>();
     }
 
     /**
      @return an instance of the type that this PrimiitveDataType Class describes.
      */
-    void* createInstance(unsigned int num) const {
+    void* createInstance(unsigned int num) const override {
         T* temp = (T*)calloc(num, sizeof(T));
         return ((void *)temp);
     }
 
     /**
      */
-    void deleteInstance(void* address) const {
+    void deleteInstance(void* address) const override {
         delete (T*)address;
     }
 

--- a/DataTypes/include/Type/StringDataType.hpp
+++ b/DataTypes/include/Type/StringDataType.hpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <stdexcept>
 
-#include "DataTypeInator.hpp"
 #include "Type/BaseType.hpp"
 
 
@@ -16,7 +15,6 @@ class StringDataType : public BaseType {
 
     /**
      Constructor for ArrayDataType.
-     @param DataTypeInator The Type resolver machine
      */
     StringDataType( ) ;
 
@@ -33,8 +31,12 @@ class StringDataType : public BaseType {
     /* ==================================================================== */
 
     /**
+     * @brief A StringDataType is always valid
+     * 
+     * @param dataTypeInator unused parameter, defaults to null
+     * @return true always
      */
-     bool validate() override;
+    bool validate(const DataTypeInator * dataTypeInator = NULL) override;
 
     bool isValid() const override;
 

--- a/DataTypes/include/Type/StructMember.hpp
+++ b/DataTypes/include/Type/StructMember.hpp
@@ -21,7 +21,7 @@ public:
      * @return true success
      * @return false failure
      */
-    bool validate(DataTypeInator* dataTypeInator);
+    bool validate(const DataTypeInator* dataTypeInator);
 
     /**
      * @brief Return true if this member is valid

--- a/DataTypes/include/TypeDictionary.hpp
+++ b/DataTypes/include/TypeDictionary.hpp
@@ -3,8 +3,9 @@
 #include <map>
 #include <string>
 #include <stdexcept>
+#include <deque>
 #include "Type/BaseType.hpp"
-
+#include "DataTypeInator.hpp"
 
 /**
  Stores name / typespecifier pairs.
@@ -28,7 +29,7 @@ class TypeDictionary {
 
     /**
      */
-    bool validate();
+    bool validate(const DataTypeInator * dataTypeInator);
 
     /**
      Dump the entire TypeDictionary to a std::string.

--- a/DataTypes/src/DataTypeInator.cpp
+++ b/DataTypes/src/DataTypeInator.cpp
@@ -2,6 +2,7 @@
 #include "Type/ArrayDataType.hpp"
 #include "Type/PointerDataType.hpp"
 #include "Utils/MutableDeclaration.hpp"
+#include "TypeDictionary.hpp"
 
 DataTypeInator::DataTypeInator () : typeDictionary(new TypeDictionary) {
     // Probably shouldn't do this.
@@ -32,13 +33,13 @@ const DataType * DataTypeInator::resolve(std::string name) const {
 
         if (this_dim == -1) {
             // Pointer case
-            result = new PointerDataType(this, next_level_decl);            
+            result = new PointerDataType(next_level_decl);            
         } else {
             // Constrained dim case
-            result = new ArrayDataType(this, next_level_decl, this_dim);
+            result = new ArrayDataType(next_level_decl, this_dim);
         }
 
-        if (!result->validate()) {
+        if (!result->validate(this)) {
             std::cerr << "Validate failed for " << result->toString() << std::endl;
         }
         return result;
@@ -50,7 +51,7 @@ void DataTypeInator::addToDictionary(std::string name, BaseType * typeSpec) {
 }
 
 bool DataTypeInator::validateDictionary() {
-    return typeDictionary->validate();
+    return typeDictionary->validate(this);
 }
 
 

--- a/DataTypes/src/Type/ArrayDataType.cpp
+++ b/DataTypes/src/Type/ArrayDataType.cpp
@@ -7,9 +7,8 @@
 #include "Utils/MutableDeclaration.hpp"
 
 // CONSTRUCTOR
-ArrayDataType:: ArrayDataType( const DataTypeInator* dataTypeInator, std::string typeSpecName, unsigned int n_elems ) : 
-                                                    typeSize(0), elementCount(n_elems), is_valid(false), typeSpecName(typeSpecName), 
-                                                    dataTypeInator(dataTypeInator) {
+ArrayDataType:: ArrayDataType( std::string typeSpecName, unsigned int n_elems ) : 
+                        typeSize(0), elementCount(n_elems), is_valid(false), typeSpecName(typeSpecName) {
     subType = NULL;
 
     if (elementCount == 0) {
@@ -25,7 +24,6 @@ ArrayDataType::ArrayDataType ( ArrayDataType const & original) {
     is_valid = original.is_valid;
     typeSpecName = original.typeSpecName;
     elementCount = original.elementCount;
-    dataTypeInator = original.dataTypeInator;
     if (original.subType != NULL) {
         subType = original.subType->clone();
     } else {
@@ -56,7 +54,6 @@ void swap(ArrayDataType& a, ArrayDataType& b)
     swap(a.is_valid, b.is_valid);
     swap(a.typeSpecName, b.typeSpecName);
     swap(a.elementCount, b.elementCount);
-    swap(a.dataTypeInator, b.dataTypeInator);
     swap(a.subType, b.subType);
 }
 
@@ -65,7 +62,7 @@ DataType * ArrayDataType::clone () const {
 }
 
 // MEMBER FUNCTION
-bool ArrayDataType::validate() {
+bool ArrayDataType::validate(const DataTypeInator * dataTypeInator) {
 
     if (!is_valid) {
 

--- a/DataTypes/src/Type/CompositeDataType.cpp
+++ b/DataTypes/src/Type/CompositeDataType.cpp
@@ -5,6 +5,7 @@
 #include "Type/StaticStructMember.hpp"
 
 #include <iostream>
+#include <sstream>
 
 CompositeDataType::CompositeDataType() {
 
@@ -13,8 +14,7 @@ CompositeDataType::CompositeDataType() {
 }
 
 // CONSTRUCTOR
-CompositeDataType::CompositeDataType( DataTypeInator* dataTypeInator,
-                                      std::string name,
+CompositeDataType::CompositeDataType( std::string name,
                                       size_t structSize,
                                       void* (*allocator)(int),
                                       void (*deAllocator)(void*) ) {
@@ -23,7 +23,6 @@ CompositeDataType::CompositeDataType( DataTypeInator* dataTypeInator,
     this->structSize = structSize;
     this->allocator = allocator;
     this->deAllocator = deAllocator;
-    this->dataTypeInator = dataTypeInator;
 }
 
 // CONSTRUCTOR
@@ -34,7 +33,6 @@ CompositeDataType::CompositeDataType ( const CompositeDataType & original ) {
     this->name = original.name;
     this->allocator = original.allocator;
     this->deAllocator = original.deAllocator;
-    this->dataTypeInator = original.dataTypeInator;
 
     for (auto member : original.normalMemberList) {
         this->normalMemberList.push_back( member->clone() );
@@ -71,7 +69,6 @@ void swap(CompositeDataType& a, CompositeDataType& b)
     swap(a.name, b.name);
     swap(a.allocator, b.allocator);
     swap(a.deAllocator, b.deAllocator);
-    swap(a.dataTypeInator, b.dataTypeInator);
     swap(a.normalMemberList , b.normalMemberList);
     swap(a.staticMemberList , b.staticMemberList);
     swap(a.structSize , b.structSize);
@@ -82,7 +79,7 @@ DataType * CompositeDataType::clone() const {
 }
 
 
-bool CompositeDataType::validate() {
+bool CompositeDataType::validate(const DataTypeInator * dataTypeInator) {
 
     // (from John) FIXME: Check for circular dependencies.
     // Also need a to check that this->subType (ptr) is not equal

--- a/DataTypes/src/Type/EnumDataType.cpp
+++ b/DataTypes/src/Type/EnumDataType.cpp
@@ -61,7 +61,7 @@ DataType * EnumDataType::clone () const {
     return new EnumDataType( *this );
 }
 
-bool EnumDataType::validate() {
+bool EnumDataType::validate(const DataTypeInator * dataTypeInator) {
     return true;
 }
 

--- a/DataTypes/src/Type/PointerDataType.cpp
+++ b/DataTypes/src/Type/PointerDataType.cpp
@@ -12,14 +12,13 @@
 
 
 // CONSTRUCTOR
-PointerDataType::PointerDataType( const DataTypeInator * datatypeInator, std::string typeSpecifierName) : typeSpecName(typeSpecifierName), dataTypeInator(datatypeInator) {}
+PointerDataType::PointerDataType( std::string typeSpecifierName) : typeSpecName(typeSpecifierName) {}
 
 // COPY CONSTRUCTOR
 PointerDataType::PointerDataType ( PointerDataType const & original) {
 
     is_valid = original.is_valid;
     typeSpecName = original.typeSpecName;
-    dataTypeInator = original.dataTypeInator;
 
     if (original.subType == NULL) {
         subType = NULL;
@@ -42,7 +41,7 @@ DataType * PointerDataType::clone () const {
 }
 
 // MEMBER FUNCTION
-bool PointerDataType::validate() {
+bool PointerDataType::validate(const DataTypeInator * dataTypeInator) {
 
     if (!is_valid) {
         subType = dataTypeInator->resolve( typeSpecName );

--- a/DataTypes/src/Type/StringDataType.cpp
+++ b/DataTypes/src/Type/StringDataType.cpp
@@ -15,7 +15,7 @@ DataType * StringDataType::clone () const {
     return new StringDataType( *this );
 }
 
-bool StringDataType::validate() {
+bool StringDataType::validate(const DataTypeInator * dataTypeInator) {
     return true;
 }
 

--- a/DataTypes/src/Type/StructMember.cpp
+++ b/DataTypes/src/Type/StructMember.cpp
@@ -11,7 +11,7 @@ StructMember::StructMember(std::string memberName, std::string typeSpecName)
                         : name(memberName), typeSpecName(typeSpecName), is_valid(false), subType(NULL) {}
 
 
-bool StructMember::validate(DataTypeInator * dataTypeInator) {
+bool StructMember::validate(const DataTypeInator * dataTypeInator) {
     if (!is_valid) {
         subType = dataTypeInator->resolve(typeSpecName);
         if (subType != NULL) {

--- a/DataTypes/src/TypeDictionary.cpp
+++ b/DataTypes/src/TypeDictionary.cpp
@@ -136,16 +136,16 @@ void TypeDictionary::addTypeDefinition(std::deque<std::string> nameParts, BaseTy
 }
 
 // MEMBER FUNCTION
-bool TypeDictionary::validate() {
+bool TypeDictionary::validate(const DataTypeInator * dataTypeInator) {
 
     bool valid = true;
     for (auto it : typeDictionary) {
-        valid &= it.second->validate();
+        valid &= it.second->validate(dataTypeInator);
     }
 
     // Validate the nested TypeDictionaries in the namespace dictionary
     for (auto it : namespaceDictionary) {
-        valid &= it.second->validate();
+        valid &= it.second->validate(dataTypeInator);
     }
 
     return valid;

--- a/DataTypes/test/ArrayTypeSpecTest.cpp
+++ b/DataTypes/test/ArrayTypeSpecTest.cpp
@@ -31,7 +31,7 @@ TEST_F( ArrayDataTypeTest , constructor_exception ) {
     ArrayDataType * arrayTypeSpec;
     bool constructor_result = true;
     try {
-        arrayTypeSpec = new ArrayDataType(dataTypeInator, "double", 0);
+        arrayTypeSpec = new ArrayDataType( "double", 0);
     } catch ( const std::logic_error& e ) {
         std::cerr << e.what();
         constructor_result = false;
@@ -50,7 +50,7 @@ TEST_F( ArrayDataTypeTest, copy_constructor ) {
 
     try {
     // Create a ArrayDataType.
-    ArrayDataType* orig = new ArrayDataType( dataTypeInator, "float", 7);
+    ArrayDataType* orig = new ArrayDataType(  "float", 7);
 
     std::cout << orig->toString();
 
@@ -77,7 +77,7 @@ TEST_F( ArrayDataTypeTest, copy_constructor ) {
 TEST_F( ArrayDataTypeTest , assignment_operator ) {
 
     // Create an ArrayDataType.
-    ArrayDataType orig = ArrayDataType( dataTypeInator, "long", 7);
+    ArrayDataType orig = ArrayDataType(  "long", 7);
 
     std::cout << orig.toString();
 
@@ -94,7 +94,7 @@ TEST_F( ArrayDataTypeTest , clone ) {
 
     // Create a ArrayDataType.
     // int cdims[] = {3,4,5,-1,-1};
-    ArrayDataType* orig = new ArrayDataType(dataTypeInator, "int**[4][5]",3);
+    ArrayDataType* orig = new ArrayDataType( "int**[4][5]",3);
     // Clone it.
     DataType * copy = orig->clone();
 
@@ -113,8 +113,8 @@ TEST_F( ArrayDataTypeTest , clone ) {
 TEST_F( ArrayDataTypeTest , getSize ) {
 
     // Create a PointerDataType.
-    ArrayDataType* ptrTypeSpec = new ArrayDataType( dataTypeInator, "long[4][5]", 3);
-    ptrTypeSpec->validate();
+    ArrayDataType* ptrTypeSpec = new ArrayDataType(  "long[4][5]", 3);
+    ptrTypeSpec->validate(dataTypeInator);
 
     // Verify that getSize returns the size of the array.
     EXPECT_EQ( sizeof(long)*60 , ptrTypeSpec->getSize());
@@ -123,10 +123,10 @@ TEST_F( ArrayDataTypeTest , getSize ) {
 TEST_F( ArrayDataTypeTest, validate_1 ) {
 
     // Create a ArrayDataType.
-    ArrayDataType* arrayTypeSpec = new ArrayDataType( dataTypeInator, "double", 4);
+    ArrayDataType* arrayTypeSpec = new ArrayDataType(  "double", 4);
 
     // Validate the Type.
-    bool validation_result = arrayTypeSpec->validate();
+    bool validation_result = arrayTypeSpec->validate(dataTypeInator);
 
     // Verify that validation succeeded.
     ASSERT_EQ(true, validation_result);
@@ -138,10 +138,10 @@ TEST_F( ArrayDataTypeTest , validate_2 ) {
     std::cout << "===== Expecting error message. =====" << std::endl;
 
     // Create an ArrayDataType.
-    ArrayDataType* arrayTypeSpec = new ArrayDataType( dataTypeInator, "Undefined_Type", 4);
+    ArrayDataType* arrayTypeSpec = new ArrayDataType(  "Undefined_Type", 4);
 
     // Validate the Type.
-    bool validation_result = arrayTypeSpec->validate();
+    bool validation_result = arrayTypeSpec->validate(dataTypeInator);
 
     // Verify that validation failed.
     ASSERT_EQ(false, validation_result);
@@ -153,7 +153,7 @@ TEST_F( ArrayDataTypeTest , getSubType_1 ) {
     ArrayDataType * arrayTypeSpec;
     bool constructor_result = true;
     try {
-        arrayTypeSpec = new ArrayDataType( dataTypeInator, "double[3]", 2);
+        arrayTypeSpec = new ArrayDataType(  "double[3]", 2);
     } catch ( const std::logic_error& e ) {
         std::cerr << e.what();
         constructor_result = false;
@@ -161,7 +161,7 @@ TEST_F( ArrayDataTypeTest , getSubType_1 ) {
     ASSERT_EQ(true, constructor_result);
 
     // Validate the Type.
-    bool validation_result = arrayTypeSpec->validate();
+    bool validation_result = arrayTypeSpec->validate(dataTypeInator);
     ASSERT_EQ(true, validation_result);
 
     // Get the subType.
@@ -181,7 +181,7 @@ TEST_F( ArrayDataTypeTest , getSubType_2 ) {
     ArrayDataType * arrayTypeSpec;
     bool constructor_result = true;
     try {
-        arrayTypeSpec = new ArrayDataType( dataTypeInator, "double", 2);
+        arrayTypeSpec = new ArrayDataType(  "double", 2);
     } catch ( const std::logic_error& e ) {
         std::cerr << e.what();
         constructor_result = false;
@@ -189,7 +189,7 @@ TEST_F( ArrayDataTypeTest , getSubType_2 ) {
     ASSERT_EQ(true, constructor_result);
 
     // Validate the Type.
-    bool validation_result = arrayTypeSpec->validate();
+    bool validation_result = arrayTypeSpec->validate(dataTypeInator);
     ASSERT_EQ(true, validation_result);
 
     // Get the SubType.

--- a/DataTypes/test/AssignValueTest.cpp
+++ b/DataTypes/test/AssignValueTest.cpp
@@ -203,8 +203,8 @@ class Foo {};
 
 TEST_F(AssignValueTest, composite) {
     // ARRANGE
-    CompositeDataType type(&dataTypeInator, "Foo", sizeof(Foo), NULL, NULL);
-    type.validate();
+    CompositeDataType type( "Foo", sizeof(Foo), NULL, NULL);
+    type.validate(&dataTypeInator);
 
     Foo var_to_assign_to;
     StringValue val ("abc");

--- a/DataTypes/test/ClearValueTest.cpp
+++ b/DataTypes/test/ClearValueTest.cpp
@@ -90,7 +90,7 @@ TEST_F(ClearValueTest, string) {
 
 TEST_F(ClearValueTest, enumerated) {
     // ARRANGE
-    addDayOfWeekEnumToTypeDictionary(&dataTypeInator, &enumDictionary);
+    addDayOfWeekEnumToTypeDictionary( &dataTypeInator, &enumDictionary);
     const DataType* type = dataTypeInator.resolve("DayOfWeek");
     DayOfWeek var_to_clear = Friday;
 
@@ -129,10 +129,10 @@ class Foo {
 
 TEST_F(ClearValueTest, composite) {
     // ARRANGE
-    CompositeDataType type(&dataTypeInator, "Foo", sizeof(Foo), NULL, NULL);
+    CompositeDataType type( "Foo", sizeof(Foo), NULL, NULL);
     type.addRegularMember("x", offsetof(Foo, x), "int");
     type.addRegularMember("y", offsetof(Foo, y), "double[5]");
-    type.validate();
+    type.validate(&dataTypeInator);
 
     Foo var_to_clear;
     var_to_clear.x = 5;

--- a/DataTypes/test/CompTypeSpecTest.cpp
+++ b/DataTypes/test/CompTypeSpecTest.cpp
@@ -138,8 +138,7 @@ TEST_F(CompositeDataTypeTest, getSize ) {
     /* Requirement: CompositeDataType::getSize() shall return the size passed in
        via the constructor. */
 
-    CompositeDataType * compTypeSpec = new CompositeDataType( dataTypeInator,
-                                                              "ClassOne",
+    CompositeDataType * compTypeSpec = new CompositeDataType( "ClassOne",
                                                               sizeof(ClassOne),
                                                               &construct<ClassOne>,
                                                               &destruct<ClassOne>);
@@ -153,8 +152,7 @@ TEST_F(CompositeDataTypeTest, getSize ) {
 
 TEST_F(CompositeDataTypeTest, assignment_operator ) {
     // ARRANGE
-    CompositeDataType  type_a(dataTypeInator,
-                                    "ClassOne",
+    CompositeDataType  type_a("ClassOne",
                                     sizeof(ClassOne),
                                     &construct<ClassOne>,
                                     &destruct<ClassOne>);
@@ -162,16 +160,15 @@ TEST_F(CompositeDataTypeTest, assignment_operator ) {
     type_a.addRegularMember( "a", offsetof(ClassOne, a), "int");
     type_a.addRegularMember( "b", offsetof(ClassOne, b), "double");
 
-    CompositeDataType  type_b(dataTypeInator,
-                                    "SomeOtherClass",
+    CompositeDataType  type_b("SomeOtherClass",
                                     4,
                                     NULL,
                                     NULL);
 
     type_b.addRegularMember( "somethingidk", 0, "int");
 
-    type_a.validate();
-    type_b.validate();
+    type_a.validate(dataTypeInator);
+    type_b.validate(dataTypeInator);
 
 
     // ACT

--- a/DataTypes/test/DataTypeInatorTest.cpp
+++ b/DataTypes/test/DataTypeInatorTest.cpp
@@ -33,7 +33,7 @@ TEST_F(DataTypeInatorTest, Array) {
     
     // ACT
     DataType * result = const_cast<DataType *>(dataTypeInator->resolve("int[5]"));
-    result->validate();
+    result->validate(dataTypeInator);
 
     // ASSERT
     const ArrayDataType * array_result = dynamic_cast<const ArrayDataType*> (result);

--- a/DataTypes/test/DataTypeTestSupport.cpp
+++ b/DataTypes/test/DataTypeTestSupport.cpp
@@ -21,12 +21,12 @@ bool addClassOneToTypeDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType* classOneTypeSpec =
-            new CompositeDataType(dataTypeInator, "ClassOne", sizeof(ClassOne), &construct<ClassOne>, &destruct<ClassOne> );
+            new CompositeDataType( "ClassOne", sizeof(ClassOne), &construct<ClassOne>, &destruct<ClassOne> );
             classOneTypeSpec->addRegularMember( "a", offsetof(ClassOne, a), "int");
             classOneTypeSpec->addRegularMember( "b", offsetof(ClassOne, b), "double");
 
         dataTypeInator->addToDictionary("ClassOne", classOneTypeSpec);
-        result = classOneTypeSpec->validate();
+        result = classOneTypeSpec->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;
@@ -39,14 +39,14 @@ bool addClassTwoToTypeDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType * classTwoTypeSpec =
-            new CompositeDataType(dataTypeInator, "ClassTwo", sizeof(ClassTwo), &construct<ClassTwo>, &destruct<ClassTwo>);
+            new CompositeDataType( "ClassTwo", sizeof(ClassTwo), &construct<ClassTwo>, &destruct<ClassTwo>);
             classTwoTypeSpec->addRegularMember( "x", offsetof(ClassTwo, x), "int");
             classTwoTypeSpec->addRegularMember( "y", offsetof(ClassTwo, y), "double");
             classTwoTypeSpec->addRegularMember( "c1", offsetof(ClassTwo, c1), "ClassOne");
 
         dataTypeInator->addToDictionary("ClassTwo", classTwoTypeSpec);
 
-        result = classTwoTypeSpec->validate();
+        result = classTwoTypeSpec->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;
@@ -59,7 +59,7 @@ bool addClassThreeToTypeDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType * classThreeTypeSpec =
-            new CompositeDataType(dataTypeInator, "ClassThree", sizeof(ClassThree), &construct<ClassThree>, &destruct<ClassThree>);
+            new CompositeDataType( "ClassThree", sizeof(ClassThree), &construct<ClassThree>, &destruct<ClassThree>);
             // int x_dims[] = {2};
             classThreeTypeSpec->addRegularMember( "pos", offsetof(ClassThree, pos), "double[2]");
             // int y_dims[] = {2};
@@ -67,7 +67,7 @@ bool addClassThreeToTypeDictionary(DataTypeInator* dataTypeInator) {
 
         dataTypeInator->addToDictionary("ClassThree", classThreeTypeSpec);
 
-        result = classThreeTypeSpec->validate();
+        result = classThreeTypeSpec->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;
@@ -80,7 +80,7 @@ bool addClassFourToTypeDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType * classFourTypeSpec =
-            new CompositeDataType(dataTypeInator, "ClassFour", sizeof(ClassFour), &construct<ClassFour>, &destruct<ClassFour>);
+            new CompositeDataType( "ClassFour", sizeof(ClassFour), &construct<ClassFour>, &destruct<ClassFour>);
             classFourTypeSpec->addRegularMember( "x", offsetof(ClassFour, x), "double[2]");
             classFourTypeSpec->addBitFieldMember( "f1", get_ClassFour__f1, set_ClassFour__f1);
             classFourTypeSpec->addBitFieldMember( "f2", get_ClassFour__f2, set_ClassFour__f2);
@@ -88,7 +88,7 @@ bool addClassFourToTypeDictionary(DataTypeInator* dataTypeInator) {
 
         dataTypeInator->addToDictionary("ClassFour", classFourTypeSpec);
 
-        result = classFourTypeSpec->validate();
+        result = classFourTypeSpec->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;
@@ -101,13 +101,13 @@ bool addClassFiveToTypeDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType * classFiveTypeSpec =
-            new CompositeDataType(dataTypeInator, "ClassFive", sizeof(ClassFive), &construct<ClassFive>, &destruct<ClassFive>);
+            new CompositeDataType( "ClassFive", sizeof(ClassFive), &construct<ClassFive>, &destruct<ClassFive>);
             classFiveTypeSpec->addRegularMember( "x", offsetof(ClassFive, x), "double");
             classFiveTypeSpec->addStaticMember( "count", &ClassFive::count, "int" );
 
         dataTypeInator->addToDictionary("ClassFive", classFiveTypeSpec);
 
-        result = classFiveTypeSpec->validate();
+        result = classFiveTypeSpec->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;
@@ -120,13 +120,13 @@ bool addClassSixToTypeDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType * classSixTypeSpec =
-            new CompositeDataType(dataTypeInator, "ClassSix", sizeof(ClassSix), &construct<ClassSix>, &destruct<ClassSix>);
+            new CompositeDataType( "ClassSix", sizeof(ClassSix), &construct<ClassSix>, &destruct<ClassSix>);
             classSixTypeSpec->addRegularMember( "char_ptr", offsetof(ClassSix, char_ptr), "char *");
             classSixTypeSpec->addRegularMember( "str", offsetof(ClassSix, str), "std::string");
 
         dataTypeInator->addToDictionary("ClassSix", classSixTypeSpec);
 
-        result = classSixTypeSpec->validate();
+        result = classSixTypeSpec->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;
@@ -139,7 +139,7 @@ bool addPointerTestClassesToDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
 
     try {
-        CompositeDataType * ClassWithNoPointersType = new CompositeDataType (dataTypeInator, "ClassWithNoPointers", sizeof(ClassWithNoPointers),    
+        CompositeDataType * ClassWithNoPointersType = new CompositeDataType ( "ClassWithNoPointers", sizeof(ClassWithNoPointers),    
                                                                             &construct<ClassWithNoPointers>, &destruct<ClassWithNoPointers>);
 
         ClassWithNoPointersType->addRegularMember( "a", offsetof(ClassWithNoPointers, a), "int");
@@ -148,13 +148,13 @@ bool addPointerTestClassesToDictionary(DataTypeInator* dataTypeInator) {
 
         dataTypeInator->addToDictionary("ClassWithNoPointers", ClassWithNoPointersType);
 
-        CompositeDataType * ClassWithPointerType = new CompositeDataType (dataTypeInator, "ClassWithPointer", sizeof(ClassWithPointer),    
+        CompositeDataType * ClassWithPointerType = new CompositeDataType ( "ClassWithPointer", sizeof(ClassWithPointer),    
                                                                     &construct<ClassWithPointer>, &destruct<ClassWithPointer>);
         
         ClassWithPointerType->addRegularMember( "a", offsetof(ClassWithPointer, a), "void *");
         dataTypeInator->addToDictionary("ClassWithPointer", ClassWithPointerType);
 
-        CompositeDataType * ClassWithNestedClassesType = new CompositeDataType (dataTypeInator, "ClassWithNestedClasses", sizeof(ClassWithNestedClasses),    
+        CompositeDataType * ClassWithNestedClassesType = new CompositeDataType ( "ClassWithNestedClasses", sizeof(ClassWithNestedClasses),    
                                                                     &construct<ClassWithNestedClasses>, &destruct<ClassWithNestedClasses>);
         
         ClassWithNestedClassesType->addRegularMember( "a", offsetof(ClassWithNestedClasses, a), "ClassWithNoPointers");
@@ -162,9 +162,9 @@ bool addPointerTestClassesToDictionary(DataTypeInator* dataTypeInator) {
 
         dataTypeInator->addToDictionary("ClassWithNestedClasses", ClassWithNestedClassesType);
 
-        result = ClassWithNoPointersType->validate();
-        result &= ClassWithPointerType->validate();
-        result &= ClassWithNestedClassesType->validate();
+        result = ClassWithNoPointersType->validate(dataTypeInator);
+        result &= ClassWithPointerType->validate(dataTypeInator);
+        result &= ClassWithNestedClassesType->validate(dataTypeInator);
 
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
@@ -187,7 +187,7 @@ bool addDayOfWeekEnumToTypeDictionary(DataTypeInator* dataTypeInator,  EnumDicti
             dataType->addEnumerator( "Saturday", 7);
 
             dataTypeInator->addToDictionary( "DayOfWeek", dataType );
-            result = dataType->validate();
+            result = dataType->validate(dataTypeInator);
     } catch( const std::logic_error& e ) {
         std::cerr << e.what();
         result = false;

--- a/DataTypes/test/GetValueTest.cpp
+++ b/DataTypes/test/GetValueTest.cpp
@@ -142,8 +142,8 @@ class Foo {};
 
 TEST_F(GetValueTest, composite) {
     // ARRANGE
-    CompositeDataType type(&dataTypeInator, "Foo", sizeof(Foo), NULL, NULL);
-    type.validate();
+    CompositeDataType type( "Foo", sizeof(Foo), NULL, NULL);
+    type.validate(&dataTypeInator);
 
     double var_to_get[5] = {1, 2, 3, 4, 5};
 

--- a/DataTypes/test/PointerTypeSpecTest.cpp
+++ b/DataTypes/test/PointerTypeSpecTest.cpp
@@ -25,7 +25,7 @@ class PointerDataTypeTest : public ::testing::Test {
 TEST_F( PointerDataTypeTest, copy_constructor ) {
 
     // Create a PointerDataType.
-    PointerDataType* orig = new PointerDataType(dataTypeInator, "float**");
+    PointerDataType* orig = new PointerDataType("float**");
 
     // Duplicate it.
     PointerDataType* copy = new PointerDataType( *(const PointerDataType*)orig );
@@ -44,7 +44,7 @@ TEST_F( PointerDataTypeTest, copy_constructor ) {
 TEST_F( PointerDataTypeTest , operator_equal ) {
 
     // Create a PointerDataType.
-    PointerDataType* orig = new PointerDataType(dataTypeInator, "long*");
+    PointerDataType* orig = new PointerDataType( "long*");
 
     // Assign it to another PointerDataType.
     PointerDataType copy = *(const PointerDataType*)orig;
@@ -62,7 +62,7 @@ TEST_F( PointerDataTypeTest , operator_equal ) {
 TEST_F( PointerDataTypeTest , clone ) {
 
     // Create a PointerDataType.
-    PointerDataType* orig = new PointerDataType(dataTypeInator, "int*");
+    PointerDataType* orig = new PointerDataType( "int*");
 
     // Clone it.
     DataType * copy = orig->clone();
@@ -81,7 +81,7 @@ TEST_F( PointerDataTypeTest , clone ) {
 TEST_F( PointerDataTypeTest , getSize ) {
 
     // Create a PointerDataType.
-    PointerDataType* ptrTypeSpec = new PointerDataType(dataTypeInator, "long**");
+    PointerDataType* ptrTypeSpec = new PointerDataType( "long**");
 
     // Verify that getSize returns the size of a pointer.
     EXPECT_EQ( sizeof(void*), ptrTypeSpec->getSize());
@@ -93,7 +93,7 @@ TEST_F( PointerDataTypeTest , getSize ) {
 //     double * d_ptr;
 
 //     // Create a PointerDataType.
-//     PointerDataType* ptrTypeSpec = new PointerDataType(dataTypeInator, "double");
+//     PointerDataType* ptrTypeSpec = new PointerDataType( "double");
 
 //     PointerValue * ptrValue = new PointerValue(&d);
 //     ptrTypeSpec->assignValue(&d_ptr, ptrValue);
@@ -107,7 +107,7 @@ TEST_F( PointerDataTypeTest , getSize ) {
 //     double * d_ptr = (double*)0x12345678;
 
 //     // Create a PointerDataType.
-//     PointerDataType* ptrTypeSpec = new PointerDataType(dataTypeInator, "double");
+//     PointerDataType* ptrTypeSpec = new PointerDataType( "double");
 
 //     // ACT
 //     Value * value = ptrTypeSpec->getValue(&d_ptr);
@@ -121,10 +121,10 @@ TEST_F( PointerDataTypeTest , getSize ) {
 TEST_F( PointerDataTypeTest , validate_1 ) {
 
     // Create a PointerDataType.
-    PointerDataType* ptrTypeSpec = new PointerDataType(dataTypeInator, "double");
+    PointerDataType* ptrTypeSpec = new PointerDataType( "double");
 
     // Validate the Type.
-    bool validation_result = ptrTypeSpec->validate();
+    bool validation_result = ptrTypeSpec->validate(dataTypeInator);
 
     // Verify that validation succeeded.
     ASSERT_EQ(true, validation_result);
@@ -136,10 +136,10 @@ TEST_F( PointerDataTypeTest , validate_2 ) {
     std::cout << "===== Expecting an error message about an undefined type. =====" << std::endl;
 
     // Create a PointerDataType.
-    PointerDataType* ptrTypeSpec = new PointerDataType(dataTypeInator, "Undefined_Type");
+    PointerDataType* ptrTypeSpec = new PointerDataType( "Undefined_Type");
 
     // Validate the Type.
-    bool validation_result = ptrTypeSpec->validate();
+    bool validation_result = ptrTypeSpec->validate(dataTypeInator);
 
     // Verify that validation failed.
     ASSERT_EQ(false, validation_result);
@@ -152,7 +152,7 @@ TEST_F( PointerDataTypeTest , getDereferencedType_1 ) {
     PointerDataType * ptrTypeSpec;
     bool constructor_result = true;
     try {
-        ptrTypeSpec = new PointerDataType(dataTypeInator, "double*");
+        ptrTypeSpec = new PointerDataType( "double*");
     } catch ( const std::logic_error& e ) {
         std::cerr << e.what();
         constructor_result = false;
@@ -160,7 +160,7 @@ TEST_F( PointerDataTypeTest , getDereferencedType_1 ) {
     ASSERT_EQ(true, constructor_result);
 
     // Validate the Type.
-    bool validation_result = ptrTypeSpec->validate();
+    bool validation_result = ptrTypeSpec->validate(dataTypeInator);
     ASSERT_EQ(true, validation_result);
 
     // Dereference the type.
@@ -189,7 +189,7 @@ TEST_F( PointerDataTypeTest , getDereferencedType_2 ) {
     PointerDataType * ptrTypeSpec;
     bool constructor_result = true;
     try {
-        ptrTypeSpec = new PointerDataType(dataTypeInator, "double");
+        ptrTypeSpec = new PointerDataType( "double");
     } catch ( const std::logic_error& e ) {
         std::cerr << e.what();
         constructor_result = false;
@@ -197,7 +197,7 @@ TEST_F( PointerDataTypeTest , getDereferencedType_2 ) {
     ASSERT_EQ(true, constructor_result);
 
     // Validate the Type.
-    bool validation_result = ptrTypeSpec->validate();
+    bool validation_result = ptrTypeSpec->validate(dataTypeInator);
     ASSERT_EQ(true, validation_result);
 
     // Dereference the type.

--- a/DataTypes/test/PrimTypeSpecTest.cpp
+++ b/DataTypes/test/PrimTypeSpecTest.cpp
@@ -527,6 +527,31 @@ TEST_F(SpecifiedPrimitiveDataTypeTest, createInstance_char) {
     EXPECT_EQ('A', *test_var);
 }
 
+TEST_F(SpecifiedPrimitiveDataTypeTest, deleteInstance) {
+    // ARRANGE
+    SpecifiedPrimitiveDataType<char> * primTypeSpec = new SpecifiedPrimitiveDataType<char>();
+    char* test_var = (char*)primTypeSpec->createInstance(1);    
+
+    // ACT
+    primTypeSpec->deleteInstance(test_var);
+
+    // ASSERT
+    // I guess just assert that it didn't segfault?
+    
+}
+
+TEST_F(SpecifiedPrimitiveDataTypeTest, clone) {
+    // ARRANGE
+    SpecifiedPrimitiveDataType<char> * primTypeSpec = new SpecifiedPrimitiveDataType<char>();
+
+    // ACT
+    DataType * cloned_type = primTypeSpec->clone();
+
+    // ASSERT
+    ASSERT_TRUE(cloned_type != primTypeSpec);    
+    ASSERT_EQ(cloned_type->toString(), primTypeSpec->toString());    
+}
+
 // -----------------------------------------------------------------------------------------
 //                                  GetValue Tests
 // -----------------------------------------------------------------------------------------

--- a/DataTypes/test/PrintValueTest.cpp
+++ b/DataTypes/test/PrintValueTest.cpp
@@ -206,7 +206,7 @@ TEST_F(PrintValueTest, null_type) {
 
 TEST_F(PrintValueTest, unvalidated_type) {
     // ARRANGE
-    const DataType* type = new ArrayDataType(&dataTypeInator, std::string("no type with this name"), 100);
+    const DataType* type = new ArrayDataType( std::string("no type with this name"), 100);
     int val_to_print = 5;
     std::stringstream ss;
 

--- a/DataTypes/test/TypeDictionaryTest.cpp
+++ b/DataTypes/test/TypeDictionaryTest.cpp
@@ -91,7 +91,7 @@ TEST_F(TypeDictionaryTest, addTypeDefinition_1) {
     DataTypeInator dataTypeInator(typeDictionary);
 
     try {
-         compTypeSpec = new CompositeDataType(&dataTypeInator, "ClassOne", sizeof(ClassOne), &construct<ClassOne>, &destruct<ClassOne>);
+         compTypeSpec = new CompositeDataType( "ClassOne", sizeof(ClassOne), &construct<ClassOne>, &destruct<ClassOne>);
          compTypeSpec->addRegularMember( "a", offsetof(ClassOne, a), "int");
          compTypeSpec->addRegularMember( "b", offsetof(ClassOne, b), "double");
 
@@ -106,7 +106,7 @@ TEST_F(TypeDictionaryTest, addTypeDefinition_1) {
     EXPECT_EQ( true, test_passed);
 
     // Verify that the types can be validated.
-    test_passed  = typeDictionary->validate();
+    test_passed  = typeDictionary->validate(&dataTypeInator);
     EXPECT_EQ( true, test_passed);
 
     // Verify that the correct DataType can be retrieved from the TypeDictionary by name.

--- a/Doxyfile
+++ b/Doxyfile
@@ -436,7 +436,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.

--- a/ICG/include/ICG_io_src_templates.hpp
+++ b/ICG/include/ICG_io_src_templates.hpp
@@ -6,6 +6,7 @@
 std::string io_src = std::string(R"(
 #include <stddef.h>
 #include <stdlib.h>
+#include <iostream>
 #include "DataTypeInator.hpp"
 #include "Type/EnumDictionary.hpp"
 #include "Type/CompositeDataType.hpp"
@@ -48,7 +49,7 @@ bool add{{ClassName_mangled}}toDictionary(DataTypeInator* dataTypeInator) {
     bool result = false;
     try {
         CompositeDataType* {{ClassName_mangled}}TypeSpec =
-            new CompositeDataType(dataTypeInator, "{{ClassName}}", sizeof({{ClassName}}), &construct<{{ClassName}}>, &destruct<{{ClassName}}> );
+            new CompositeDataType("{{ClassName}}", sizeof({{ClassName}}), &construct<{{ClassName}}>, &destruct<{{ClassName}}> );
             {{list_field_decl}}
 
         dataTypeInator->addToDictionary("{{ClassName}}", {{ClassName_mangled}}TypeSpec);


### PR DESCRIPTION
Some of the DataTypes used to take the DataTypeInator as a parameter in the constructor and keep it as a member, and then only ever used it in validate method. Change them to only take DataTypeInator as a const * in validate and not keep it as a member anymore.